### PR TITLE
Update plugin for hapi v19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - 8
-  - 10
   - 12
   - 13
   - node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 # Changelog
 
 
-## [1.1.0](https://github.com/futurestudio/hapi-rate-limitor/compare/v1.0.0...v1.1.0) - 2019-11-xx
+## [2.0.0](https://github.com/futurestudio/hapi-jwt/compare/v1.1.0...v2.0.0) - 2020-xx-xx
+
+### Updated
+- bump dependencies
+- switch packages from `jws` to `jose`
+
+
+### Breaking Changes
+- requires Node.js v12
+
+
+## [1.1.0](https://github.com/futurestudio/hapi-jwt/compare/v1.0.0...v1.1.0) - 2019-11-xx
 
 ### Added
 - checks to ensure a token when decoding a JWT

--- a/package.json
+++ b/package.json
@@ -7,19 +7,18 @@
     "url": "https://github.com/futurestudio/hapi-jwt/issues"
   },
   "dependencies": {
-    "@hapi/joi": "~16.1.8",
+    "@hapi/joi": "~17.0.0",
     "dayjs": "~1.8.18",
     "deepmerge": "~4.2.2",
     "hapi-request-utilities": "~3.0.0",
-    "jose": "~1.18.1",
-    "jws": "~4.0.0"
+    "jose": "~1.18.1"
   },
   "devDependencies": {
-    "@hapi/catbox": "~10.2.3",
+    "@hapi/catbox": "~11.0.0",
     "@hapi/catbox-redis": "~5.0.5",
-    "@hapi/code": "~7.0.0",
+    "@hapi/code": "~8.0.1",
     "@hapi/hapi": "~18.4.0",
-    "@hapi/lab": "~22.0.2",
+    "@hapi/lab": "~22.0.3",
     "eslint": "~6.8.0",
     "eslint-config-standard": "~14.1.0",
     "eslint-plugin-import": "~2.19.1",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "url": "git+https://github.com/futurestudio/hapi-jwt.git"
   },
   "scripts": {
-    "format": "eslint **/*.js --fix",
-    "lint": "eslint **/*.js",
+    "format": "eslint ./src/**/*.js --fix",
+    "lint": "eslint ./src/**/*.js",
     "test": "lab --assert @hapi/code --leaks --coverage --lint --reporter console --output stdout --reporter html --output ./coverage/coverage.html",
     "test:single": "lab --assert @hapi/code --leaks --lint --id",
     "test:list": "lab --assert @hapi/code --dry --verbose"

--- a/package.json
+++ b/package.json
@@ -8,29 +8,30 @@
   },
   "dependencies": {
     "@hapi/joi": "~16.1.8",
-    "dayjs": "~1.8.17",
+    "dayjs": "~1.8.18",
     "deepmerge": "~4.2.2",
     "hapi-request-utilities": "~3.0.0",
-    "jws": "~3.2.2"
+    "jose": "~1.18.1",
+    "jws": "~4.0.0"
   },
   "devDependencies": {
     "@hapi/catbox": "~10.2.3",
     "@hapi/catbox-redis": "~5.0.5",
     "@hapi/code": "~7.0.0",
     "@hapi/hapi": "~18.4.0",
-    "@hapi/lab": "~22.0.1",
+    "@hapi/lab": "~22.0.2",
     "eslint": "~6.8.0",
     "eslint-config-standard": "~14.1.0",
-    "eslint-plugin-import": "~2.19.0",
-    "eslint-plugin-node": "~10.0.0",
+    "eslint-plugin-import": "~2.19.1",
+    "eslint-plugin-node": "~11.0.0",
     "eslint-plugin-promise": "~4.2.1",
     "eslint-plugin-standard": "~4.0.1",
     "husky": "~3.1.0",
     "node-forge": "~0.9.1",
-    "sinon": "~7.5.0"
+    "sinon": "~8.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12"
   },
   "homepage": "https://github.com/futurestudio/hapi-jwt#readme",
   "husky": {

--- a/test/providers/jws.js
+++ b/test/providers/jws.js
@@ -110,6 +110,10 @@ describe('JWS Provider', () => {
     expect(result).to.equal(payload)
   })
 
+  it('throws when creating an unsigned JWT (algo none)', async () => {
+    expect(() => new JWS({ options: { secret, algorithm: 'none' } })).to.throw()
+  })
+
   it('creates a token with string payload', async () => {
     const payload = 'Hello Marcus'
 

--- a/test/providers/jws.js
+++ b/test/providers/jws.js
@@ -8,7 +8,7 @@ const Forge = require('node-forge')
 const { expect } = require('@hapi/code')
 const Token = require('../../src/token')
 const MockKeys = require('../mocks/keys')
-const JwsProvider = require('../../src/providers/jws')
+const JWS = require('../../src/providers/jws')
 
 const { describe, it, before, after } = exports.lab = Lab.script()
 
@@ -52,7 +52,7 @@ describe('JWS Provider', () => {
   it('encode an decode a symmetric JWS, HS256)', async () => {
     const payload = { jti: 1 }
 
-    const jws = new JwsProvider({ options: { secret, algorithm: 'HS256' } })
+    const jws = new JWS({ options: { secret, algorithm: 'HS256' } })
     const jwt = await jws.encode(payload)
 
     const token = new Token(jwt)
@@ -69,7 +69,7 @@ describe('JWS Provider', () => {
     }
 
     const payload = { jti: 1, sub: 'Marcus' }
-    const jws = new JwsProvider({ options: { secret, keys, algorithm: 'RS256' } })
+    const jws = new JWS({ options: { secret, keys, algorithm: 'RS256' } })
     const jwt = await jws.encode(payload)
     const token = new Token(jwt)
     expect(token.isValid()).to.be.true()
@@ -84,7 +84,7 @@ describe('JWS Provider', () => {
     const privateKeyAsOpenSSH = Forge.ssh.privateKeyToOpenSSH(privateKey)
 
     const payload = { jti: 1, sub: 'Marcus' }
-    const jws = new JwsProvider({ options: { keys: {}, algorithm: 'RS256' } })
+    const jws = new JWS({ options: { keys: {}, algorithm: 'RS256' } })
     jws.getSigningKey = async () => { return privateKeyAsOpenSSH }
     jws.getVerificationKey = async () => { return publicKeyAsPem }
 
@@ -98,7 +98,7 @@ describe('JWS Provider', () => {
 
   it('encodes and decodes a JWS using ED25519 keys (asymmetric, ES256)', async () => {
     const payload = { jti: 1, sub: 'Marcus' }
-    const jws = new JwsProvider({ options: { keys: {}, algorithm: 'ES256' } })
+    const jws = new JWS({ options: { keys: {}, algorithm: 'ES256' } })
     jws.getSigningKey = async () => { return MockKeys.es256.private }
     jws.getVerificationKey = async () => { return MockKeys.es256.public }
 
@@ -110,17 +110,10 @@ describe('JWS Provider', () => {
     expect(result).to.equal(payload)
   })
 
-  it('creates an unsigned JWT (algo none)', async () => {
-    const jws = new JwsProvider({ options: { secret, algorithm: 'none' } })
-    const jwt = await jws.encode({ jti: 1, sub: 'Marcus' })
-    const token = new Token(jwt)
-    expect(token.isValid()).to.be.true()
-  })
-
   it('creates a token with string payload', async () => {
     const payload = 'Hello Marcus'
 
-    const jws = new JwsProvider({ options: { secret, algorithm: 'HS256' } })
+    const jws = new JWS({ options: { secret, algorithm: 'HS256' } })
     const jwt = await jws.encode(payload)
 
     const token = new Token(jwt)
@@ -131,41 +124,41 @@ describe('JWS Provider', () => {
   })
 
   it('throws when creating a token without payload', async () => {
-    const jws = new JwsProvider({ options: { secret, algorithm: 'HS256' } })
+    const jws = new JWS({ options: { secret, algorithm: 'HS256' } })
     await expect(jws.encode()).to.reject()
   })
 
   it('throws when creating a token with null payload', async () => {
-    const jws = new JwsProvider({ options: { secret, algorithm: 'HS256' } })
+    const jws = new JWS({ options: { secret, algorithm: 'HS256' } })
     await expect(jws.encode(null)).to.reject()
   })
 
   it('ensures valid algorithm', async () => {
     expect(() => {
       // eslint-disable-next-line
-      new JwsProvider({ options: { secret, algorithm: 'not-available' } })
+      new JWS({ options: { secret, algorithm: 'not-available' } })
     }
     ).to.throw()
   })
 
   it('throws on error when encoding', async () => {
-    const jws = new JwsProvider({ options: { secret, algorithm: 'HS256' } })
+    const jws = new JWS({ options: { secret, algorithm: 'HS256' } })
     jws.getAlgorithm = () => { return 'invalid' }
     await expect(jws.encode('value')).to.reject()
   })
 
   it('throws when decoding an empty token', async () => {
-    const jws = new JwsProvider({ options: { secret, algorithm: 'HS256' } })
+    const jws = new JWS({ options: { secret, algorithm: 'HS256' } })
     await expect(jws.decode()).to.reject('Cannot decode JWT, received: undefined')
   })
 
   it('throws when decoding a null token', async () => {
-    const jws = new JwsProvider({ options: { secret, algorithm: 'HS256' } })
+    const jws = new JWS({ options: { secret, algorithm: 'HS256' } })
     await expect(jws.decode(null)).to.reject('Cannot decode JWT, received: null')
   })
 
   it('throws when decoding an invalid token', async () => {
-    const jws = new JwsProvider({ options: { secret, algorithm: 'HS256' } })
+    const jws = new JWS({ options: { secret, algorithm: 'HS256' } })
     await expect(jws.decode('token.notMatching.theSecret')).to.reject('Invalid token')
   })
 
@@ -174,7 +167,7 @@ describe('JWS Provider', () => {
       private: './wrong-path'
     }
 
-    const jws = new JwsProvider({ options: { secret, keys, algorithm: 'RS256' } })
+    const jws = new JWS({ options: { secret, keys, algorithm: 'RS256' } })
     await expect(jws.encode('payload')).to.reject()
   })
 
@@ -183,7 +176,7 @@ describe('JWS Provider', () => {
       private: './wrong-path'
     }
 
-    const jws = new JwsProvider({ options: { secret, keys, algorithm: 'RS256' } })
+    const jws = new JWS({ options: { secret, keys, algorithm: 'RS256' } })
     jws.fileExists = () => { return true }
     await expect(jws.encode('payload')).to.reject()
   })


### PR DESCRIPTION
This PR updates the plugin to Node.js 12 in preparation for the upcoming hapi 19 release. Because hapi 19 will only support Node.js v12+, this PR will also bump the required Node.js version for this package to v12.

This change enables the usage of the [`jose`](https://github.com/panva/jose) package. The `jose` package contains classes which allow us to create encrypted tokens. Encrypted tokens are a planned feature for one of the upcoming releases.

This PR introduces the following breaking changes:

- require Node.js v12
- removed `'none'` algorithm in favor of increased security (and because `jose` doesn’t support unsigned tokens :))